### PR TITLE
Add prefix key and pane sync indicators

### DIFF
--- a/basic.tmuxtheme
+++ b/basic.tmuxtheme
@@ -2,7 +2,7 @@
 # Basic theme
 #
 
-# Themepack format options
+# Themepack options
 set -goq @themepack-status-left-area-left-format "#S"
 set -goq @themepack-status-left-area-middle-format "#I"
 set -goq @themepack-status-left-area-right-format "#P"
@@ -11,6 +11,16 @@ set -goq @themepack-status-right-area-middle-format "%H:%M:%S"
 set -goq @themepack-status-right-area-right-format "%d-%b-%y"
 set -goq @themepack-window-status-current-format "#I:#W#F"
 set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goqF @themepack-prefix-key-on-format "#{s/C-/\^/:prefix}"
+set -goq  @themepack-prefix-key-off-format "  "
+set -goq  @themepack-pane-sync-on-format "SYNC"
+set -goq  @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on " #[fg=black]#[bg=cyan] #{@themepack-prefix-key-on-format} #[default] "
+set -goqF @themepack-prefix-key-off "  #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=black]#[bg=yellow] #{@themepack-pane-sync-on-format} #[default] "
+set -goqF @themepack-pane-sync-off "  #{@themepack-pane-sync-off-format}  "
 
 # Customizable prefixes and suffixes for @themepack-* format options
 set -goq @themepack-status-left-area-left-prefix ""
@@ -39,6 +49,14 @@ set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-a
 set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
 set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
 set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
 
 # Theme options
 set -goq  @theme-clock-mode-colour red

--- a/powerline/block/blue.tmuxtheme
+++ b/powerline/block/blue.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour24
 set -goq @powerline-color-main-2 colour33
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/cyan.tmuxtheme
+++ b/powerline/block/cyan.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour39
 set -goq @powerline-color-main-2 colour81
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/gray.tmuxtheme
+++ b/powerline/block/gray.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour245
 set -goq @powerline-color-main-2 colour250
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/green.tmuxtheme
+++ b/powerline/block/green.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour100
 set -goq @powerline-color-main-2 colour190
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/magenta.tmuxtheme
+++ b/powerline/block/magenta.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour125
 set -goq @powerline-color-main-2 colour127
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/orange.tmuxtheme
+++ b/powerline/block/orange.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour130
 set -goq @powerline-color-main-2 colour166
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/purple.tmuxtheme
+++ b/powerline/block/purple.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour90
 set -goq @powerline-color-main-2 colour129
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/red.tmuxtheme
+++ b/powerline/block/red.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour88
 set -goq @powerline-color-main-2 colour160
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/block/yellow.tmuxtheme
+++ b/powerline/block/yellow.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour227
 set -goq @powerline-color-main-2 colour227
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-main-1}"

--- a/powerline/default/blue.tmuxtheme
+++ b/powerline/default/blue.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour24
 set -goq @powerline-color-main-2 colour33
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/cyan.tmuxtheme
+++ b/powerline/default/cyan.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour39
 set -goq @powerline-color-main-2 colour81
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/gray.tmuxtheme
+++ b/powerline/default/gray.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour245
 set -goq @powerline-color-main-2 colour250
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/green.tmuxtheme
+++ b/powerline/default/green.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour100
 set -goq @powerline-color-main-2 colour190
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/magenta.tmuxtheme
+++ b/powerline/default/magenta.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour125
 set -goq @powerline-color-main-2 colour127
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/orange.tmuxtheme
+++ b/powerline/default/orange.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour130
 set -goq @powerline-color-main-2 colour166
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/purple.tmuxtheme
+++ b/powerline/default/purple.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour90
 set -goq @powerline-color-main-2 colour129
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/red.tmuxtheme
+++ b/powerline/default/red.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour88
 set -goq @powerline-color-main-2 colour160
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/default/yellow.tmuxtheme
+++ b/powerline/default/yellow.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour227
 set -goq @powerline-color-main-2 colour227
@@ -79,6 +41,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -98,15 +116,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/blue.tmuxtheme
+++ b/powerline/double/blue.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour24
 set -goq @powerline-color-main-2 colour33
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/cyan.tmuxtheme
+++ b/powerline/double/cyan.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour39
 set -goq @powerline-color-main-2 colour81
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/green.tmuxtheme
+++ b/powerline/double/green.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour100
 set -goq @powerline-color-main-2 colour190
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/magenta.tmuxtheme
+++ b/powerline/double/magenta.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour125
 set -goq @powerline-color-main-2 colour127
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/orange.tmuxtheme
+++ b/powerline/double/orange.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour130
 set -goq @powerline-color-main-2 colour166
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/purple.tmuxtheme
+++ b/powerline/double/purple.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour90
 set -goq @powerline-color-main-2 colour129
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/red.tmuxtheme
+++ b/powerline/double/red.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour88
 set -goq @powerline-color-main-2 colour160
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/powerline/double/yellow.tmuxtheme
+++ b/powerline/double/yellow.tmuxtheme
@@ -8,44 +8,6 @@
 # https://github.com/powerline/fonts
 #
 
-# Themepack format options
-set -goq @themepack-status-left-area-left-format "#S"
-set -goq @themepack-status-left-area-middle-format "#(whoami)"
-set -goq @themepack-status-left-area-right-format "#I:#P"
-set -goq @themepack-status-right-area-left-format "%H:%M:%S"
-set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
-set -goq @themepack-status-right-area-right-format "#H"
-set -goq @themepack-window-status-current-format "#I:#W#F"
-set -goq @themepack-window-status-format "#I:#W#F"
-
-# Customizable prefixes and suffixes for @themepack-* format options
-set -goq @themepack-status-left-area-left-prefix ""
-set -goq @themepack-status-left-area-left-suffix ""
-set -goq @themepack-status-left-area-middle-prefix ""
-set -goq @themepack-status-left-area-middle-suffix ""
-set -goq @themepack-status-left-area-right-prefix ""
-set -goq @themepack-status-left-area-right-suffix ""
-set -goq @themepack-status-right-area-left-prefix ""
-set -goq @themepack-status-right-area-left-suffix ""
-set -goq @themepack-status-right-area-middle-prefix ""
-set -goq @themepack-status-right-area-middle-suffix ""
-set -goq @themepack-status-right-area-right-prefix ""
-set -goq @themepack-status-right-area-right-suffix ""
-set -goq @themepack-window-status-current-prefix ""
-set -goq @themepack-window-status-current-suffix ""
-set -goq @themepack-window-status-prefix ""
-set -goq @themepack-window-status-suffix ""
-
-# Apply prefixes and suffixes to @themepack-* format options
-set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
-set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
-set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
-set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
-set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
-set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
-set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
-set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
-
 # Powerline color options
 set -goq @powerline-color-main-1 colour227
 set -goq @powerline-color-main-2 colour227
@@ -82,6 +44,62 @@ set -goqF @powerline-status-right-area-right-fg "#{@powerline-status-bg}"
 set -goqF @powerline-status-right-bg "#{@powerline-color-grey-1}"
 set -goqF @powerline-status-right-fg "#{@powerline-color-grey-5}"
 
+# Themepack options
+set -goq @themepack-status-left-area-left-format "#S"
+set -goq @themepack-status-left-area-middle-format "#(whoami)"
+set -goq @themepack-status-left-area-right-format "#I:#P"
+set -goq @themepack-status-right-area-left-format "%H:%M:%S"
+set -goq @themepack-status-right-area-middle-format "%d-%b-%y"
+set -goq @themepack-status-right-area-right-format "#H"
+set -goq @themepack-window-status-current-format "#I:#W#F"
+set -goq @themepack-window-status-format "#I:#W#F"
+
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+# Customizable prefixes and suffixes for @themepack-* format options
+set -goq @themepack-status-left-area-left-prefix ""
+set -goq @themepack-status-left-area-left-suffix ""
+set -goq @themepack-status-left-area-middle-prefix ""
+set -goq @themepack-status-left-area-middle-suffix ""
+set -goq @themepack-status-left-area-right-prefix ""
+set -goq @themepack-status-left-area-right-suffix ""
+set -goq @themepack-status-right-area-left-prefix ""
+set -goq @themepack-status-right-area-left-suffix ""
+set -goq @themepack-status-right-area-middle-prefix ""
+set -goq @themepack-status-right-area-middle-suffix ""
+set -goq @themepack-status-right-area-right-prefix ""
+set -goq @themepack-status-right-area-right-suffix ""
+set -goq @themepack-window-status-current-prefix ""
+set -goq @themepack-window-status-current-suffix ""
+set -goq @themepack-window-status-prefix ""
+set -goq @themepack-window-status-suffix ""
+
+# Apply prefixes and suffixes to @themepack-* format options
+set -gqF @themepack-status-left-area-left-format "#{@themepack-status-left-area-left-prefix}#{@themepack-status-left-area-left-format}#{@themepack-status-left-area-left-suffix}"
+set -gqF @themepack-status-left-area-middle-format "#{@themepack-status-left-area-middle-prefix}#{@themepack-status-left-area-middle-format}#{@themepack-status-left-area-middle-suffix}"
+set -gqF @themepack-status-left-area-right-format "#{@themepack-status-left-area-right-prefix}#{@themepack-status-left-area-right-format}#{@themepack-status-left-area-right-suffix}"
+set -gqF @themepack-status-right-area-left-format "#{@themepack-status-right-area-left-prefix}#{@themepack-status-right-area-left-format}#{@themepack-status-right-area-left-suffix}"
+set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-area-middle-prefix}#{@themepack-status-right-area-middle-format}#{@themepack-status-right-area-middle-suffix}"
+set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
+set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
+set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"
+
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
@@ -101,15 +119,15 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""
 set -goqF @theme-window-status-current-bg "#{@powerline-color-black-1}"

--- a/src/_themepack-setup.tmuxsh
+++ b/src/_themepack-setup.tmuxsh
@@ -25,3 +25,11 @@ set -gqF @themepack-status-right-area-middle-format "#{@themepack-status-right-a
 set -gqF @themepack-status-right-area-right-format "#{@themepack-status-right-area-right-prefix}#{@themepack-status-right-area-right-format}#{@themepack-status-right-area-right-suffix}"
 set -gqF @themepack-window-status-current-format "#{@themepack-window-status-current-prefix}#{@themepack-window-status-current-format}#{@themepack-window-status-current-suffix}"
 set -gqF @themepack-window-status-format "#{@themepack-window-status-prefix}#{@themepack-window-status-format}#{@themepack-window-status-suffix}"
+
+# Prefix key status
+set -goq @themepack-prefix-key-status "#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}"
+set -gqF @theme-status-left-suffix "#{@theme-status-left-suffix}#{@themepack-prefix-key-status}"
+
+# Pane Sync status
+set -goq @themepack-pane-sync-status "#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}"
+set -gqF @theme-status-right-prefix "#{@themepack-pane-sync-status}#{@theme-status-right-prefix}"

--- a/src/basic.tmuxtheme
+++ b/src/basic.tmuxtheme
@@ -2,7 +2,7 @@
 # Basic theme
 #
 
-# Themepack format options
+# Themepack options
 set -goq @themepack-status-left-area-left-format "#S"
 set -goq @themepack-status-left-area-middle-format "#I"
 set -goq @themepack-status-left-area-right-format "#P"
@@ -12,7 +12,17 @@ set -goq @themepack-status-right-area-right-format "%d-%b-%y"
 set -goq @themepack-window-status-current-format "#I:#W#F"
 set -goq @themepack-window-status-format "#I:#W#F"
 
-#= include "_themepack-options-affixes"
+set -goqF @themepack-prefix-key-on-format "#{s/C-/\^/:prefix}"
+set -goq  @themepack-prefix-key-off-format "  "
+set -goq  @themepack-pane-sync-on-format "SYNC"
+set -goq  @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on " #[fg=black]#[bg=cyan] #{@themepack-prefix-key-on-format} #[default] "
+set -goqF @themepack-prefix-key-off "  #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=black]#[bg=yellow] #{@themepack-pane-sync-on-format} #[default] "
+set -goqF @themepack-pane-sync-off "  #{@themepack-pane-sync-off-format}  "
+
+#= include "_themepack-setup"
 
 # Theme options
 set -goq  @theme-clock-mode-colour red

--- a/src/powerline/_theme-options.tmuxsh
+++ b/src/powerline/_theme-options.tmuxsh
@@ -17,14 +17,14 @@ set -goqF @theme-status-bg "#{@powerline-status-bg}"
 set -goqF @theme-status-fg "#{@powerline-status-fg}"
 set -goq  @theme-status-interval 1
 set -goq  @theme-status-justify centre
-set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} #[fg=#{@powerline-status-left-area-right-bg},bg=#{@theme-status-bg},nobold]"
+set -goqF @theme-status-left "#[fg=#{@powerline-status-left-area-left-fg},bg=#{@powerline-status-left-area-left-bg},bold] #{@themepack-status-left-area-left-format} #[fg=#{@powerline-status-left-area-left-bg},bg=#{@powerline-status-left-area-middle-bg},nobold]#[fg=#{@powerline-status-left-area-middle-fg},bg=#{@powerline-status-left-area-middle-bg}] #{@themepack-status-left-area-middle-format} #[fg=#{@powerline-status-left-area-middle-bg},bg=#{@powerline-status-left-area-right-bg}]#[fg=#{@powerline-status-left-area-right-fg},bg=#{@powerline-status-left-area-right-bg}] #{@themepack-status-left-area-right-format} "
 set -goqF @theme-status-left-bg "#{@powerline-status-left-bg}"
 set -goqF @theme-status-left-fg "#{@powerline-status-left-fg}"
 set -goq  @theme-status-left-length 40
-set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-bg},bg=#{@theme-status-bg}]#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
+set -goqF @theme-status-right "#[fg=#{@powerline-status-right-area-left-fg},bg=#{@powerline-status-right-area-left-bg}] #{@themepack-status-right-area-left-format} #[fg=#{@powerline-status-right-area-middle-bg},bg=#{@powerline-status-right-area-left-bg}]#[fg=#{@powerline-status-right-area-middle-fg},bg=#{@powerline-status-right-area-middle-bg}] #{@themepack-status-right-area-middle-format} #[fg=#{@powerline-status-right-area-right-bg},bg=#{@powerline-status-right-area-middle-bg}]#[fg=#{@powerline-status-right-area-right-fg},bg=#{@powerline-status-right-area-right-bg},bold] #{@themepack-status-right-area-right-format} "
 set -goqF @theme-status-right-bg "#{@powerline-status-right-bg}"
 set -goqF @theme-status-right-fg "#{@powerline-status-right-fg}"
 set -goq  @theme-status-right-length 150
-set -goqF @theme-window-status-activity-bg "#{@theme-status-bg}"
+set -goqF @theme-window-status-activity-bg "#{@powerline-status-bg}"
 set -goqF @theme-window-status-activity-fg "#{@powerline-color-activity-1}"
 set -goq  @theme-window-status-separator ""

--- a/src/powerline/_themepack-options.tmuxsh
+++ b/src/powerline/_themepack-options.tmuxsh
@@ -1,4 +1,4 @@
-# Themepack format options
+# Themepack options
 set -goq @themepack-status-left-area-left-format "#S"
 set -goq @themepack-status-left-area-middle-format "#(whoami)"
 set -goq @themepack-status-left-area-right-format "#I:#P"
@@ -8,4 +8,14 @@ set -goq @themepack-status-right-area-right-format "#H"
 set -goq @themepack-window-status-current-format "#I:#W#F"
 set -goq @themepack-window-status-format "#I:#W#F"
 
-#= include "_themepack-options-affixes"
+set -goq @themepack-prefix-key-on-format "."
+set -goq @themepack-prefix-key-off-format " "
+set -goq @themepack-pane-sync-on-format "SYNC"
+set -goq @themepack-pane-sync-off-format "    "
+
+set -goqF @themepack-prefix-key-on "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-color-black-1}]#[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-color-black-1}] #{@themepack-prefix-key-on-format} #[fg=#{@powerline-status-bg}]#[bg=#{@powerline-color-black-1}]"
+set -goqF @themepack-prefix-key-off "#[fg=#{@powerline-status-left-area-right-bg}]#[bg=#{@powerline-status-bg}] #{@themepack-prefix-key-off-format}  "
+set -goqF @themepack-pane-sync-on " #[fg=#{@powerline-color-main-2}]#[bg=#{@powerline-status-bg}]#[fg=#{@powerline-color-black-1}]#[bg=#{@powerline-color-main-2}] #{@themepack-pane-sync-on-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-color-main-2}]"
+set -goqF @themepack-pane-sync-off "   #{@themepack-pane-sync-off-format} #[fg=#{@powerline-status-right-area-left-bg}]#[bg=#{@powerline-status-bg}]"
+
+#= include "_themepack-setup"

--- a/src/powerline/block/_base.tmuxsh
+++ b/src/powerline/block/_base.tmuxsh
@@ -5,6 +5,8 @@ set -goqF @powerline-color-activity-1 "#{@powerline-color-main-3}"
 
 #= include "powerline/_powerline-options"
 
+#= include "powerline/_themepack-options"
+
 #= include "powerline/_theme-options"
 #= include "powerline/_theme-options-block"
 

--- a/src/powerline/block/blue.tmuxtheme
+++ b/src/powerline/block/blue.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Blue Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/blue"
 #= include "powerline/block/_base"

--- a/src/powerline/block/cyan.tmuxtheme
+++ b/src/powerline/block/cyan.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Cyan Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/cyan"
 #= include "powerline/block/_base"

--- a/src/powerline/block/gray.tmuxtheme
+++ b/src/powerline/block/gray.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Gray Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/gray"
 #= include "powerline/block/_base"

--- a/src/powerline/block/green.tmuxtheme
+++ b/src/powerline/block/green.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Green Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/green"
 #= include "powerline/block/_base"

--- a/src/powerline/block/magenta.tmuxtheme
+++ b/src/powerline/block/magenta.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Magenta Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/magenta"
 #= include "powerline/block/_base"

--- a/src/powerline/block/orange.tmuxtheme
+++ b/src/powerline/block/orange.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Orange Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/orange"
 #= include "powerline/block/_base"

--- a/src/powerline/block/purple.tmuxtheme
+++ b/src/powerline/block/purple.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Purple Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/purple"
 #= include "powerline/block/_base"

--- a/src/powerline/block/red.tmuxtheme
+++ b/src/powerline/block/red.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Red Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/red"
 #= include "powerline/block/_base"

--- a/src/powerline/block/yellow.tmuxtheme
+++ b/src/powerline/block/yellow.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Yellow Block - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/yellow"
 #= include "powerline/block/_base"

--- a/src/powerline/default/_base.tmuxsh
+++ b/src/powerline/default/_base.tmuxsh
@@ -2,6 +2,8 @@
 
 #= include "powerline/_powerline-options"
 
+#= include "powerline/_themepack-options"
+
 #= include "powerline/_theme-options"
 #= include "powerline/_theme-options-default"
 

--- a/src/powerline/default/blue.tmuxtheme
+++ b/src/powerline/default/blue.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Blue - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/blue"
 #= include "powerline/default/_base"

--- a/src/powerline/default/cyan.tmuxtheme
+++ b/src/powerline/default/cyan.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Cyan - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/cyan"
 #= include "powerline/default/_base"

--- a/src/powerline/default/gray.tmuxtheme
+++ b/src/powerline/default/gray.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Gray - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/gray"
 #= include "powerline/default/_base"

--- a/src/powerline/default/green.tmuxtheme
+++ b/src/powerline/default/green.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Green - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/green"
 #= include "powerline/default/_base"

--- a/src/powerline/default/magenta.tmuxtheme
+++ b/src/powerline/default/magenta.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Magenta - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/magenta"
 #= include "powerline/default/_base"

--- a/src/powerline/default/orange.tmuxtheme
+++ b/src/powerline/default/orange.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Orange - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/orange"
 #= include "powerline/default/_base"

--- a/src/powerline/default/purple.tmuxtheme
+++ b/src/powerline/default/purple.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Purple - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/purple"
 #= include "powerline/default/_base"

--- a/src/powerline/default/red.tmuxtheme
+++ b/src/powerline/default/red.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Red - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/red"
 #= include "powerline/default/_base"

--- a/src/powerline/default/yellow.tmuxtheme
+++ b/src/powerline/default/yellow.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Yellow - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/yellow"
 #= include "powerline/default/_base"

--- a/src/powerline/double/_base.tmuxsh
+++ b/src/powerline/double/_base.tmuxsh
@@ -5,6 +5,8 @@ set -goqF @powerline-status-right-area-right-bg "#{@powerline-color-main-1}"
 
 #= include "powerline/_powerline-options"
 
+#= include "powerline/_themepack-options"
+
 #= include "powerline/_theme-options"
 #= include "powerline/_theme-options-default"
 

--- a/src/powerline/double/blue.tmuxtheme
+++ b/src/powerline/double/blue.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Blue - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/blue"
 #= include "powerline/double/_base"

--- a/src/powerline/double/cyan.tmuxtheme
+++ b/src/powerline/double/cyan.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Cyan - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/cyan"
 #= include "powerline/double/_base"

--- a/src/powerline/double/green.tmuxtheme
+++ b/src/powerline/double/green.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Green - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/green"
 #= include "powerline/double/_base"

--- a/src/powerline/double/magenta.tmuxtheme
+++ b/src/powerline/double/magenta.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Magenta - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/magenta"
 #= include "powerline/double/_base"

--- a/src/powerline/double/orange.tmuxtheme
+++ b/src/powerline/double/orange.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Orange - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/orange"
 #= include "powerline/double/_base"

--- a/src/powerline/double/purple.tmuxtheme
+++ b/src/powerline/double/purple.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Purple - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/purple"
 #= include "powerline/double/_base"

--- a/src/powerline/double/red.tmuxtheme
+++ b/src/powerline/double/red.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Red - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/red"
 #= include "powerline/double/_base"

--- a/src/powerline/double/yellow.tmuxtheme
+++ b/src/powerline/double/yellow.tmuxtheme
@@ -2,8 +2,6 @@
 # Powerline Double Yellow - Tmux Themepack
 #= include "powerline/_info"
 
-#= include "powerline/_themepack-options"
-
 # Powerline color options
 #= include "powerline/_colors/yellow"
 #= include "powerline/double/_base"

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -30,16 +30,20 @@ func TestBasicTheme(t *testing.T) {
 	})
 
 	tmuxHasOptions(t, theme, tmux.GlobalSession, tmux.Options{
+		"@themepack-prefix-key-on":    " #[fg=black]#[bg=cyan] ^b #[default] ",
+		"@themepack-prefix-key-off":   "      ",
+		"@themepack-pane-sync-on":     " #[fg=black]#[bg=yellow] SYNC #[default] ",
+		"@themepack-pane-sync-off":    "        ",
 		"display-panes-active-colour": "default",
 		"display-panes-colour":        "default",
 		"message-command-style":       "default",
 		"message-style":               "default",
 		"status-interval":             "1",
 		"status-justify":              "centre",
-		"status-left":                 "#S #[fg=white]» #[fg=yellow]#I #[fg=cyan]#P",
+		"status-left":                 "#S #[fg=white]» #[fg=yellow]#I #[fg=cyan]#P" + powerlinePrefixKeyStatus,
 		"status-left-length":          "40",
 		"status-left-style":           "fg=green,bg=black",
-		"status-right":                "#H #[fg=white]« #[fg=yellow]%H:%M:%S #[fg=green]%d-%b-%y",
+		"status-right":                powerlinePaneSyncStatus + "#H #[fg=white]« #[fg=yellow]%H:%M:%S #[fg=green]%d-%b-%y",
 		"status-right-length":         "40",
 		"status-right-style":          "fg=cyan,bg=black",
 		"status-style":                "fg=cyan,bg=black",
@@ -91,8 +95,8 @@ func TestBasicThemeOverrides(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertHasPrefix(t, opts["status-left"], "SLP=")
-	assertHasSuffix(t, opts["status-left"], "=SLS")
-	assertHasPrefix(t, opts["status-right"], "SRP=")
+	assertHasSuffix(t, opts["status-left"], "=SLS"+powerlinePrefixKeyStatus)
+	assertHasPrefix(t, opts["status-right"], powerlinePaneSyncStatus+"SRP=")
 	assertHasSuffix(t, opts["status-right"], "=SRS")
 
 	opts, err = tm.GetOptions(tmux.GlobalWindow)

--- a/test/powerline.go
+++ b/test/powerline.go
@@ -1,5 +1,8 @@
 package test
 
+var powerlinePrefixKeyStatus = `#{?client_prefix,#{@themepack-prefix-key-on},#{@themepack-prefix-key-off}}`
+var powerlinePaneSyncStatus = `#{?pane_synchronized,#{@themepack-pane-sync-on},#{@themepack-pane-sync-off}}`
+
 var powerlineColors = map[string]struct {
 	filename string
 	color1   string

--- a/test/powerline_block_test.go
+++ b/test/powerline_block_test.go
@@ -47,16 +47,20 @@ func TestPowerlineBlockThemes(t *testing.T) {
 		})
 
 		tmuxHasOptions(t, filename, tmux.GlobalSession, tmux.Options{
+			"@themepack-pane-sync-off":    "        #[fg=colour235]#[bg=colour233]",
+			"@themepack-pane-sync-on":     " #[fg=" + c.color2 + "]#[bg=colour233]#[fg=black]#[bg=" + c.color2 + "] SYNC #[fg=colour235]#[bg=" + c.color2 + "]",
+			"@themepack-prefix-key-off":   "#[fg=colour235]#[bg=colour233]    ",
+			"@themepack-prefix-key-on":    "#[fg=colour235]#[bg=black]#[fg=" + c.color2 + "]#[bg=black] . #[fg=colour233]#[bg=black]",
 			"display-panes-active-colour": "colour245",
 			"display-panes-colour":        "colour233",
 			"message-command-style":       "fg=black,bg=" + c.color1,
 			"message-style":               "fg=black,bg=" + c.color1,
 			"status-interval":             "1",
 			"status-justify":              "centre",
-			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]\ue0b0#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]\ue0b0#[fg=colour240,bg=colour235] #I:#P #[fg=colour235,bg=colour233,nobold]\ue0b0",
+			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]#[fg=colour240,bg=colour235] #I:#P " + powerlinePrefixKeyStatus,
 			"status-left-length":          "40",
 			"status-left-style":           "fg=colour243,bg=colour233",
-			"status-right":                "#[fg=colour235,bg=colour233]\ue0b2#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]\ue0b2#[fg=colour233,bg=colour240] %d-%b-%y #[fg=colour245,bg=colour240]\ue0b2#[fg=colour233,bg=colour245,bold] #H ",
+			"status-right":                powerlinePaneSyncStatus + "#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]#[fg=colour233,bg=colour240] %d-%b-%y #[fg=colour245,bg=colour240]#[fg=colour233,bg=colour245,bold] #H ",
 			"status-right-length":         "150",
 			"status-right-style":          "fg=colour243,bg=colour233",
 			"status-style":                "fg=colour240,bg=colour233",
@@ -113,8 +117,8 @@ func TestPowerlineBlockThemeOverrides(t *testing.T) {
 		assert.NoError(t, err)
 
 		assertHasPrefix(t, opts["status-left"], "SLP=")
-		assertHasSuffix(t, opts["status-left"], "=SLS")
-		assertHasPrefix(t, opts["status-right"], "SRP=")
+		assertHasSuffix(t, opts["status-left"], "=SLS"+powerlinePrefixKeyStatus)
+		assertHasPrefix(t, opts["status-right"], powerlinePaneSyncStatus+"SRP=")
 		assertHasSuffix(t, opts["status-right"], "=SRS")
 
 		opts, err = tm.GetOptions(tmux.GlobalWindow)

--- a/test/powerline_default_test.go
+++ b/test/powerline_default_test.go
@@ -40,23 +40,27 @@ func TestPowerlineDefaultThemes(t *testing.T) {
 			"pane-active-border-style":     "fg=" + c.color1,
 			"pane-border-style":            "fg=colour238",
 			"window-status-activity-style": "fg=colour245,bg=colour233",
-			"window-status-current-format": "#[fg=colour233,bg=black]\ue0b0#[fg=" + c.color2 + ",nobold] #I:#W#F #[fg=colour233,bg=black,nobold]\ue0b2",
+			"window-status-current-format": "#[fg=colour233,bg=black]#[fg=" + c.color2 + ",nobold] #I:#W#F #[fg=colour233,bg=black,nobold]",
 			"window-status-current-style":  "fg=" + c.color2 + ",bg=black",
 			"window-status-format":         "  #I:#W#F  ",
 			"window-status-separator":      "",
 		})
 
 		tmuxHasOptions(t, name, tmux.GlobalSession, tmux.Options{
+			"@themepack-pane-sync-off":    "        #[fg=colour235]#[bg=colour233]",
+			"@themepack-pane-sync-on":     " #[fg=" + c.color2 + "]#[bg=colour233]#[fg=black]#[bg=" + c.color2 + "] SYNC #[fg=colour235]#[bg=" + c.color2 + "]",
+			"@themepack-prefix-key-off":   "#[fg=colour235]#[bg=colour233]    ",
+			"@themepack-prefix-key-on":    "#[fg=colour235]#[bg=black]#[fg=" + c.color2 + "]#[bg=black] . #[fg=colour233]#[bg=black]",
 			"display-panes-active-colour": "colour245",
 			"display-panes-colour":        "colour233",
 			"message-command-style":       "fg=black,bg=" + c.color1,
 			"message-style":               "fg=black,bg=" + c.color1,
 			"status-interval":             "1",
 			"status-justify":              "centre",
-			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]\ue0b0#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]\ue0b0#[fg=colour240,bg=colour235] #I:#P #[fg=colour235,bg=colour233,nobold]\ue0b0",
+			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]#[fg=colour240,bg=colour235] #I:#P " + powerlinePrefixKeyStatus,
 			"status-left-length":          "40",
 			"status-left-style":           "fg=colour243,bg=colour233",
-			"status-right":                "#[fg=colour235,bg=colour233]\ue0b2#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]\ue0b2#[fg=colour233,bg=colour240] %d-%b-%y #[fg=colour245,bg=colour240]\ue0b2#[fg=colour233,bg=colour245,bold] #H ",
+			"status-right":                powerlinePaneSyncStatus + "#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]#[fg=colour233,bg=colour240] %d-%b-%y #[fg=colour245,bg=colour240]#[fg=colour233,bg=colour245,bold] #H ",
 			"status-right-length":         "150",
 			"status-right-style":          "fg=colour243,bg=colour233",
 			"status-style":                "fg=colour240,bg=colour233",
@@ -113,8 +117,8 @@ func TestPowerlineDefaultThemeOverrides(t *testing.T) {
 		assert.NoError(t, err)
 
 		assertHasPrefix(t, opts["status-left"], "SLP=")
-		assertHasSuffix(t, opts["status-left"], "=SLS")
-		assertHasPrefix(t, opts["status-right"], "SRP=")
+		assertHasSuffix(t, opts["status-left"], "=SLS"+powerlinePrefixKeyStatus)
+		assertHasPrefix(t, opts["status-right"], powerlinePaneSyncStatus+"SRP=")
 		assertHasSuffix(t, opts["status-right"], "=SRS")
 
 		opts, err = tm.GetOptions(tmux.GlobalWindow)

--- a/test/powerline_double_test.go
+++ b/test/powerline_double_test.go
@@ -39,23 +39,27 @@ func TestPowerlineDoubleThemes(t *testing.T) {
 			"pane-active-border-style":     "fg=" + c.color1,
 			"pane-border-style":            "fg=colour238",
 			"window-status-activity-style": "fg=colour245,bg=colour233",
-			"window-status-current-format": "#[fg=colour233,bg=black]\ue0b0#[fg=" + c.color2 + ",nobold] #I:#W#F #[fg=colour233,bg=black,nobold]\ue0b2",
+			"window-status-current-format": "#[fg=colour233,bg=black]#[fg=" + c.color2 + ",nobold] #I:#W#F #[fg=colour233,bg=black,nobold]",
 			"window-status-current-style":  "fg=" + c.color2 + ",bg=black",
 			"window-status-format":         "  #I:#W#F  ",
 			"window-status-separator":      "",
 		})
 
 		tmuxHasOptions(t, filename, tmux.GlobalSession, tmux.Options{
+			"@themepack-pane-sync-off":    "        #[fg=colour235]#[bg=colour233]",
+			"@themepack-pane-sync-on":     " #[fg=" + c.color2 + "]#[bg=colour233]#[fg=black]#[bg=" + c.color2 + "] SYNC #[fg=colour235]#[bg=" + c.color2 + "]",
+			"@themepack-prefix-key-off":   "#[fg=colour235]#[bg=colour233]    ",
+			"@themepack-prefix-key-on":    "#[fg=colour235]#[bg=black]#[fg=" + c.color2 + "]#[bg=black] . #[fg=colour233]#[bg=black]",
 			"display-panes-active-colour": "colour245",
 			"display-panes-colour":        "colour233",
 			"message-command-style":       "fg=black,bg=" + c.color1,
 			"message-style":               "fg=black,bg=" + c.color1,
 			"status-interval":             "1",
 			"status-justify":              "centre",
-			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]\ue0b0#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]\ue0b0#[fg=colour240,bg=colour235] #I:#P #[fg=colour235,bg=colour233,nobold]\ue0b0",
+			"status-left":                 "#[fg=colour233,bg=" + c.color1 + ",bold] #S #[fg=" + c.color1 + ",bg=colour240,nobold]#[fg=colour233,bg=colour240] #(whoami) #[fg=colour240,bg=colour235]#[fg=colour240,bg=colour235] #I:#P " + powerlinePrefixKeyStatus,
 			"status-left-length":          "40",
 			"status-left-style":           "fg=colour243,bg=colour233",
-			"status-right":                "#[fg=colour235,bg=colour233]\ue0b2#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]\ue0b2#[fg=colour233,bg=colour240] %d-%b-%y #[fg=" + c.color1 + ",bg=colour240]\ue0b2#[fg=colour233,bg=" + c.color1 + ",bold] #H ",
+			"status-right":                powerlinePaneSyncStatus + "#[fg=colour240,bg=colour235] %H:%M:%S #[fg=colour240,bg=colour235]#[fg=colour233,bg=colour240] %d-%b-%y #[fg=" + c.color1 + ",bg=colour240]#[fg=colour233,bg=" + c.color1 + ",bold] #H ",
 			"status-right-length":         "150",
 			"status-right-style":          "fg=colour243,bg=colour233",
 			"status-style":                "fg=colour240,bg=colour233",
@@ -112,8 +116,8 @@ func TestPowerlineDoubleThemeOverrides(t *testing.T) {
 		assert.NoError(t, err)
 
 		assertHasPrefix(t, opts["status-left"], "SLP=")
-		assertHasSuffix(t, opts["status-left"], "=SLS")
-		assertHasPrefix(t, opts["status-right"], "SRP=")
+		assertHasSuffix(t, opts["status-left"], "=SLS"+powerlinePrefixKeyStatus)
+		assertHasPrefix(t, opts["status-right"], powerlinePaneSyncStatus+"SRP=")
 		assertHasSuffix(t, opts["status-right"], "=SRS")
 
 		opts, err = tm.GetOptions(tmux.GlobalWindow)


### PR DESCRIPTION
The indicators used can be customized:

- For the prefix key indicator, set `@themepack-prefix-key-on-format`
and `@themepack-prefix-key-off-format` options. The off format must be
the same length as the on format to avoid weird behavior.
- For the pane sync indicator, set `@themepack-pane-sync-on-format` and
`@themepack-pane-sync-off-format` options. The off format must be the
same length as the on format to avoid weird behavior.

## To-Do

- [ ] Fix duplicated and glitchy indicators when reloading tmux configuration.
- [ ] Figure out if there's an easy way for users disable the indicators if they don't want them.

## Gifs

### Prefix Key Indicator

Basic theme:

![basic-prefix-key-indicator](https://user-images.githubusercontent.com/39563/71328965-504e3680-2517-11ea-97f8-a78eb2376f28.gif)

Powerline themes:

![powerline-prefix-key-indicator](https://user-images.githubusercontent.com/39563/71328972-5cd28f00-2517-11ea-82c7-7526bae65ec2.gif)

### Pane Sync Indicator

Basic theme:

![basic-pane-sync-indicator](https://user-images.githubusercontent.com/39563/71328998-6d830500-2517-11ea-81e6-8fc6528f2fb3.gif)

Powerline themes:

![powerline-pane-sync-indicator](https://user-images.githubusercontent.com/39563/71329015-74117c80-2517-11ea-952d-600f19cbed93.gif)
