### PR TITLE
Better pane number indicator perceptibility (active: main theme colour)

### DIFF
--- a/src/powerline/_theme-options.tmuxsh
+++ b/src/powerline/_theme-options.tmuxsh
@@ -1,8 +1,8 @@
 # Theme options
 set -goqF @theme-clock-mode-colour "#{@powerline-color-main-1}"
 set -goq  @theme-clock-mode-style 24
-set -goqF @theme-display-panes-active-colour "#{@powerline-color-grey-6}"
-set -goqF @theme-display-panes-colour "#{@powerline-color-grey-1}"
+set -goqF @theme-display-panes-active-colour "#{@powerline-color-main-1}"
+set -goqF @theme-display-panes-colour "#{@powerline-color-grey-4}"
 set -goqF @theme-message-bg "#{@powerline-color-main-1}"
 set -goqF @theme-message-command-bg "#{@powerline-color-main-1}"
 set -goqF @theme-message-command-fg "#{@powerline-color-black-1}"


### PR DESCRIPTION
I use this in my tmux config `bind-key -n C-y select-pane -t :.+ \; display-panes -b` to cycle panes and show the pane numbers. Before, the active pane number was shown in light gray and the inactive panes' numbers in nearly black. Now, the latter are shown in gray and the active one in the main theme colour, which looks much nicer IMHO : )

(@debian: should update their package xD)